### PR TITLE
Skip property enumeration for primitive-like types.

### DIFF
--- a/Tababular.Tests/Extractors/TestObjectTableExtractor.cs
+++ b/Tababular.Tests/Extractors/TestObjectTableExtractor.cs
@@ -93,5 +93,18 @@ namespace Tababular.Tests.Extractors
 
         }
 
+
+        [Test]
+        public void CanExtractListOfPrimitiveObjects()
+        {
+            var objects = new List<string> { "line1", "line2", "line3" };
+            
+            var table = new ObjectTableExtractor(objects).GetTable();
+                                           
+            Assert.That(table.Rows.Count, Is.EqualTo(3));
+            Assert.That(table.Rows[0].GetAllCells().Single().Lines, Is.EqualTo(new[] { "line1" }));
+            Assert.That(table.Rows[1].GetAllCells().Single().Lines, Is.EqualTo(new[] { "line2" }));
+            Assert.That(table.Rows[2].GetAllCells().Single().Lines, Is.EqualTo(new[] { "line3" }));
+        }
     }
 }

--- a/Tababular/Internals/Extractors/ObjectTableExtractor.cs
+++ b/Tababular/Internals/Extractors/ObjectTableExtractor.cs
@@ -24,13 +24,22 @@ namespace Tababular.Internals.Extractors
             {
                 var row = new Row();
 
-                foreach (var property in objectRow.GetType().GetProperties())
+                if (System.Convert.GetTypeCode(objectRow) == System.TypeCode.Object)
                 {
-                    var name = property.Name;
-                    var column = columns.GetOrAdd(name, _ => new Column(name));
-                    var value = property.GetValue(objectRow, null);
+                    foreach (var property in objectRow.GetType().GetProperties())
+                    {
+                        var name = property.Name;
+                        var column = columns.GetOrAdd(name, _ => new Column(name));
+                        var value = property.GetValue(objectRow, null);
 
-                    row.AddCell(column, new Cell(value));
+                        row.AddCell(column, new Cell(value));
+                    }
+                }
+                else
+                {
+                    string name = objectRow.GetType().Name;
+                    var column = columns.GetOrAdd(name, _ => new Column(name));
+                    row.AddCell(column, new Cell(objectRow));
                 }
 
                 rows.Add(row);


### PR DESCRIPTION
  i.e. don't display the "Chars" property of a string, display the string.

This came about after trying to pass a list of strings or ints.

Wasn't sure on what the column header should be though; so went with typename.  perhaps some functionality for overriding column headers next?

